### PR TITLE
Zabbix-Docker-Dashboard: Bugfix: Regex filter "sysadm-docker01"

### DIFF
--- a/Docker-1596316390504.json
+++ b/Docker-1596316390504.json
@@ -3795,7 +3795,7 @@
         "options": [],
         "query": "$Group.*",
         "refresh": 1,
-        "regex": "sysadm-docker01",
+        "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",


### PR DESCRIPTION
First of all: Thank you for providing this template, it's lovely! I've found a little problem in the template which should be fixed.
This setting may be valid for your environment, but for general purposes I assume this regex should be removed.

![image](https://github.com/VGzsysadm/Grafana-dashboards/assets/8781699/d89a8049-53a7-4052-ac69-e84a2bf4802e)
